### PR TITLE
Climbing cost added, block limits removed

### DIFF
--- a/Gamemode Mods/Development/Starcore_Pointslist-Dev/Data/Scripts/Additions/PointAdditions.cs
+++ b/Gamemode Mods/Development/Starcore_Pointslist-Dev/Data/Scripts/Additions/PointAdditions.cs
@@ -569,7 +569,7 @@ Cat_StarcoreUlitity@21;
 
 Cat_BadModder@22;			
 				  APE_Strong@200; 
-				  GoalieCasemate@200;
+				  GoalieCasemate@175;
 				Reaver_Coilgun@125; 
 					Assault_Coil_Turret@125;
 				Priest_Block@125; 
@@ -585,26 +585,26 @@ Cat_BadModder@22;
 				  Type22_Driver@675; 
 				   Type25_Driver@1000; 
 
-				UnguidedRocketTurret@100; 
-				 DrunkRocketTurret@400; 
+				UnguidedRocketTurret@75; 
+				 DrunkRocketTurret@300; 
  				  Devastator_Torp@625;
 				X4_7x7_HeavyTurret@300;
 				 KreegMagnetarCannon@400;				
 				HeavyLanceBattery@1000;
-				 HadeanPlasmaBlastgun@900; 
-				  VindicatorKineticLance@800;
+				 HadeanPlasmaBlastgun@825; 
+				  VindicatorKineticLance@750;
 
 				 Fixed_Rockets@250;
 				JN_175Fixed@1350; 
-				 Thagomizer@750; 
-					 Thagomizer_Flipped@750; 
-						 Thagomizer_Angled@750; 
-							 Thagomizer_Angled_Flipped@750; 
+				 Thagomizer@635; 
+					 Thagomizer_Flipped@635; 
+						 Thagomizer_Angled@635; 
+							 Thagomizer_Angled_Flipped@635; 
 
 
 Cat_Strikecraft@23;
-				HeavyFighterBay@300; 
-					longsword@400;
+				HeavyFighterBay@230; 
+					longsword@625;
 				TaiidanSingleHangar@100;
 					TaiidanRailFighter@700;
 						TaiidanHangarFighter@800;

--- a/Gamemode Mods/Development/Starcore_Sharetrack-Dev/Data/Scripts/ShipPoints/ShipTracker.cs
+++ b/Gamemode Mods/Development/Starcore_Sharetrack-Dev/Data/Scripts/ShipPoints/ShipTracker.cs
@@ -676,6 +676,31 @@ namespace klime.PointCheck
                     t_N = "Gothic Torpedo";
                     mCs = 0.15f;
                     break;
+                case "[MID] AX 'Spitfire' Light Rocket Turret":
+                    t_N = "Spitfire Turret";
+                    mCs = 0.15f;
+                case "[FLAW] Naval RL-10x 'Avalanche' Medium Range Launchers":
+                case "[FLAW] Naval RL-10x 'Avalanche' Angled Medium Range Launchers":
+                    t_N = "RL-10x Avalanche";
+                    mCs = 0.15f;
+                case "[MID] LK 'Bonfire' Guided Rocket Turret":
+                    t_N = "Bonfire Turret";
+                    mCs = 0.2f;
+                case "[FLAW] Warp Beacon - Longsword":
+                    t_N = "Longsword Bomber";
+                    mCs = 0.2f;
+                case "[FLAW] Phoenix Snubfighter Launch Bay":
+                    t_N = "Snubfighters";
+                    mCs = 0.1f;
+                case "[FLAW] Hadean Superheavy Plasma Blastguns":
+                    t_N = "Plasma Blastgun";
+                    mCs = 0.121f;
+                case "[FLAW] Vindicator Kinetic Battery":
+                    t_N = "Kinetic Battery";
+                    mCs = 0.120f;
+                case "[FLAW] Goalkeeper Casemate Flak Battery":
+                    t_N = "Goalkeeper Flakwall";
+                    mCs = 0.119f;
             }
         }
 

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/DemolisherX4_7x7.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/DemolisherX4_7x7.sbc
@@ -7,7 +7,7 @@
 				<TypeId>ConveyorSorter</TypeId>
 				<SubtypeId>X4_7x7_HeavyTurret</SubtypeId>
 			</Id>
-			<DisplayName>[CA] X4 'Demolisher' Heavy Plasma Howitzer</DisplayName>
+			<DisplayName>[FLAW] X4 'Demolisher' Heavy Plasma Howitzer</DisplayName>
 			<Description>[6.5km Targeting Range [750 m/s]]
               [Energy damage]
               [High Damage, Large AOE, Long Reload, Innaccurate]

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/GoalkeeperFlakwallCubeblock.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/GoalkeeperFlakwallCubeblock.sbc
@@ -7,7 +7,7 @@
 				<TypeId>ConveyorSorter</TypeId>
 				<SubtypeId>GoalieCasemate</SubtypeId>
 			</Id>
-			<DisplayName>[CA] Goalkeeper Casemate Flak Battery</DisplayName>
+			<DisplayName>[FLAW] Goalkeeper Casemate Flak Battery</DisplayName>
 			<Description>
               [1600 Targeting Range]
 			  [1200 Flak Range]

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/Hadean_PlasmaBlastgun_Cubeblocks.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/Hadean_PlasmaBlastgun_Cubeblocks.sbc
@@ -8,7 +8,7 @@
 				<TypeId>ConveyorSorter</TypeId>
 				<SubtypeId>HadeanPlasmaBlastgun</SubtypeId>
 			</Id>
-			<DisplayName>[CA] Hadean Superheavy Plasma Blastguns</DisplayName>
+			<DisplayName>[FLAW] Hadean Superheavy Plasma Blastguns</DisplayName>
             <Description>
 			8km range, 1250 m/s velocity
 			Plasma Vaporizes Hull armor with extreme Thermal Energy damage

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/HailfireRocketTurret.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/HailfireRocketTurret.sbc
@@ -7,7 +7,7 @@
 				<TypeId>ConveyorSorter</TypeId>
 				<SubtypeId>DrunkRocketTurret</SubtypeId>
 			</Id>
-			<DisplayName>[MID] EX 'Bonfire' Guided Rocket Turret</DisplayName>
+			<DisplayName>[MID] LK 'Bonfire' Guided Rocket Turret</DisplayName>
 			<Description>[4km Targeting Range [300 m/s]]
               [Energy damage]
 			  [3 HP Guided Missiles]

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/LBX_Cubeblocks.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/LBX_Cubeblocks.sbc
@@ -8,7 +8,7 @@
 			  <TypeId>ConveyorSorter</TypeId>
 			  <SubtypeId>JN_175Fixed</SubtypeId>
 		  </Id>
-		  <DisplayName>[CA] Naval LB-5X</DisplayName>
+		  <DisplayName>[FLAW] Naval LB-5X</DisplayName>
 		  <Description>
 		  Long Ranged, 2 ammo types.
 		  +High Explosive - Energy Damage 2km Blast Zone, please use with caution. 900m/s

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/Magnus_FusionCannons.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/Magnus_FusionCannons.sbc
@@ -16,7 +16,7 @@
 				<TypeId>LargeMissileTurret</TypeId> -->
 				<SubtypeId>KreegMagnetarCannon</SubtypeId>
 			</Id>
-			<DisplayName>[CA] Magnus Fusion Cannons</DisplayName>
+			<DisplayName>[FLAW] Magnus Fusion Cannons</DisplayName>
 			<Description>[6km Targeting Range [1200 m/s]]
               [Energy damage]
               [Anti-Shield]

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/PhoenixSnubfighter_Cubeblocks.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/PhoenixSnubfighter_Cubeblocks.sbc
@@ -8,11 +8,11 @@
 				<TypeId>ConveyorSorter</TypeId>
 				<SubtypeId>HeavyFighterBay</SubtypeId>
 			</Id>
-			<DisplayName>[MID] Phoenix Snubfighter Launch Bay</DisplayName>
+			<DisplayName>[FLAW] Phoenix Snubfighter Launch Bay</DisplayName>
       		<Description>Launches Powerful strikecraft. Please have target selected, then turn shoot ON, to launch fighters.
      		 Capacity: 1
      		 MaxActive = 1
-			 500 HP Fighter, Holds 10 seconds of ammo for its onboard High Powered Laser.
+			 900 HP Fighter, Holds 10 seconds of ammo for its onboard High Powered Laser.
 			 Deals 300 AMS damage per second.
 				Managed by heat. 'Hawk' and 'Argonaut' Variants to follow.
      		 </Description>		

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/RLX_Cubeblocks.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/RLX_Cubeblocks.sbc
@@ -7,7 +7,7 @@
 			  <TypeId>ConveyorSorter</TypeId>
 			  <SubtypeId>Thagomizer</SubtypeId>
 		  </Id>
-		  <DisplayName>[CA] Naval RL-10x 'Avalanche' Medium Range Launchers</DisplayName>
+		  <DisplayName>[FLAW] Naval RL-10x 'Avalanche' Medium Range Launchers</DisplayName>
 		  <Description>
 			  10 Barrels of High Explosive Rockets
 			  400m minimum range, 13500m max

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/RLX_Cubeblocks.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/RLX_Cubeblocks.sbc
@@ -10,7 +10,7 @@
 		  <DisplayName>[FLAW] Naval RL-10x 'Avalanche' Medium Range Launchers</DisplayName>
 		  <Description>
 			  10 Barrels of High Explosive Rockets
-			  400m minimum range, 13500m max
+			  400m minimum range, 11500m max
 			  Kinetic Damage
 			  Draws 100MW
 		  </Description>
@@ -69,12 +69,12 @@
 			  <TypeId>ConveyorSorter</TypeId>
 			  <SubtypeId>Thagomizer_Flipped</SubtypeId>
 		  </Id>
-		  <DisplayName>[MID] Naval RL-10x 'Avalanche' Medium Range Launchers</DisplayName>
+		  <DisplayName>[FLAW] Naval RL-10x 'Avalanche' Medium Range Launchers</DisplayName>
 		  <Description>
 			  10 Barrels of High Explosive Rockets
-			  400m minimum range, 13500m max
+			  400m minimum range, 11500m max
 			  Kinetic Damage
-
+			  Draws 100MW
 		  </Description>
 		  <Icon>Textures\GUI\Icons\Cubes\tempiconRLX.png</Icon>
 		  <CubeSize>Large</CubeSize>
@@ -132,12 +132,12 @@
 			  <TypeId>ConveyorSorter</TypeId>
 			  <SubtypeId>Thagomizer_Angled</SubtypeId>
 		  </Id>
-		  <DisplayName>[MID] Naval RL-10x 'Avalanche' Angled Medium Range Launchers</DisplayName>
+		  <DisplayName>[FLAW] Naval RL-10x 'Avalanche' Angled Medium Range Launchers</DisplayName>
 		  <Description>
 			  10 Barrels of High Explosive Rockets
-			  400m minimum range, 13500m max
+			  400m minimum range, 11500m max
 			  Kinetic Damage
-
+			  Draws 100MW
 		  </Description>
 		  <Icon>Textures\GUI\Icons\Cubes\tempiconRLX.png</Icon>
 		  <CubeSize>Large</CubeSize>
@@ -198,12 +198,12 @@
 			  <TypeId>ConveyorSorter</TypeId>
 			  <SubtypeId>Thagomizer_Angled_Flipped</SubtypeId>
 		  </Id>
-		  <DisplayName>[MID] Naval RL-10x 'Avalanche' Angled Medium Range Launchers</DisplayName>
+		  <DisplayName>[FLAW] Naval RL-10x 'Avalanche' Angled Medium Range Launchers</DisplayName>
 		  <Description>
 			  10 Barrels of High Explosive Rockets
-			  400m minimum range, 13500m max
+			  400m minimum range, 11500m max
 			  Kinetic Damage
-
+			  Draws 100MW
 		  </Description>
 		  <Icon>Textures\GUI\Icons\Cubes\tempiconRLX.png</Icon>
 		  <CubeSize>Large</CubeSize>

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/ShipwreckCarronade.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/ShipwreckCarronade.sbc
@@ -7,7 +7,7 @@
                 <TypeId>ConveyorSorter</TypeId>
                 <SubtypeId>HeavyCarronade_5x5_Turret</SubtypeId>
             </Id>
-            <DisplayName>[CA] 'Shipwreck' Heavy Carronade</DisplayName>
+            <DisplayName>[FLAW] 'Shipwreck' Heavy Carronade</DisplayName>
             <Description>
               [2.5km Targeting Range]
               [Energy damage]

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/SuperheavyFixedGauss.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/SuperheavyFixedGauss.sbc
@@ -8,7 +8,7 @@
 			  <TypeId>ConveyorSorter</TypeId>
 			  <SubtypeId>NavalHeavyGaussRifle</SubtypeId>
 		  </Id>
-		  <DisplayName>[CA]'Grizzly' Naval Heavy Gauss Rifle</DisplayName>
+		  <DisplayName>[FLAW] [WIP] 'Grizzly' Naval Heavy Gauss Rifle</DisplayName>
 		  <Description>
 		  9km Range. Kinetic. Short Ranged. 4 Second Targeting Beam, 1/60th of a second Hypervelocity Slug
 		  WIP, trying to make a hitscan feel like a bullet is hard.

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/Vindicator_Supercannon_Cubeblocks.sbc
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/SBC CubeBlocks/Vindicator_Supercannon_Cubeblocks.sbc
@@ -15,7 +15,7 @@
 				<TypeId>LargeMissileTurret</TypeId>
 				<SubtypeId>VindicatorKineticLance</SubtypeId>
 			</Id>
-			<DisplayName>[CA] Vindicator Kinetic Battery</DisplayName>
+			<DisplayName>[FLAW] Vindicator Kinetic Battery</DisplayName>
             <Description>
 			9KM range, 4000m/s velocity
 			Kinetic Damage

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Carronade/QuadCarronadeAmmo.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Carronade/QuadCarronadeAmmo.cs
@@ -121,7 +121,7 @@ namespace Scripts
                     Armor = -1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 2f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
@@ -509,7 +509,7 @@ namespace Scripts
                     Armor = -1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 4f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Flak MachineGuns LightCannons/GoalieMultiTurretParts.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Flak MachineGuns LightCannons/GoalieMultiTurretParts.cs
@@ -147,7 +147,7 @@ namespace Scripts {
                 },
                 Other = new OtherDef
                 {
-                    ConstructPartCap = 4, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
+                    ConstructPartCap = 0, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
                     RotateBarrelAxis = 0, // For spinning barrels, which axis to spin the barrel around; 0 = none.
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Large SnubFighters/HeavyFighterBay.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Large SnubFighters/HeavyFighterBay.cs
@@ -136,7 +136,7 @@ namespace Scripts {
                 },
                 Other = new OtherDef
                 {
-                    ConstructPartCap = 12, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
+                    ConstructPartCap = 0, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
                     RotateBarrelAxis = 0, // For spinning barrels, which axis to spin the barrel around; 0 = none.
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = true, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Magnetic Weapons/Superheavys_Vindicator_WeaponParts.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Magnetic Weapons/Superheavys_Vindicator_WeaponParts.cs
@@ -142,7 +142,7 @@ namespace Scripts {
                 },
                 Other = new OtherDef
                 {
-                    ConstructPartCap = 4, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
+                    ConstructPartCap = 0, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
                     RotateBarrelAxis = 0, // For spinning barrels, which axis to spin the barrel around; 0 = none.
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/MasterConfig.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/MasterConfig.cs
@@ -17,7 +17,7 @@
                 MagDriver_Type19,
                 MagDriver_Type22,
                 MagDriver_Type25,
-                /*UNSC_Coilgun_Block*/ 
+                UNSC_Coilgun_Block,
                 LightTurret_Reaver,
                 HeavyFixedRockets, 
                 //ParticleLance_Type17,

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Plasma Weapons/Superheavys_Hadean_WeaponParts.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Plasma Weapons/Superheavys_Hadean_WeaponParts.cs
@@ -142,7 +142,7 @@ namespace Scripts {
                 },
                 Other = new OtherDef
                 {
-                    ConstructPartCap = 4, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
+                    ConstructPartCap = 0, // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
                     RotateBarrelAxis = 0, // For spinning barrels, which axis to spin the barrel around; 0 = none.
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Plasma Weapons/X-4PlasAmmo.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Plasma Weapons/X-4PlasAmmo.cs
@@ -386,9 +386,9 @@ namespace Scripts
                     },
                     OffsetEffect = new OffsetEffectDef
                     {
-                        MaxOffset = 0,// 0 offset value disables this effect
-                        MinLength = 0.2f,
-                        MaxLength = 3,
+                        MaxOffset = 0, // 0 offset value disables this effect //how far away it can be from the straight line
+                        MinLength = 0.2f, //
+                        MaxLength = 3, //segment length
                     },
                 },
             },

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Rockets and Torpedoes/BonfireMissileLauncher.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Rockets and Torpedoes/BonfireMissileLauncher.cs
@@ -125,7 +125,7 @@ namespace Scripts {
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.
                     Debug = false, // Force enables debug mode.
-                    RestrictionRadius = 20, // Prevents other blocks of this type from being placed within this distance of the centre of the block.
+                    RestrictionRadius = 15, // Prevents other blocks of this type from being placed within this distance of the centre of the block.
                     CheckInflatedBox = true, // If true, the above distance check is performed from the edge of the block instead of the centre.
                     CheckForAnyWeapon = false, // If true, the check will fail if ANY weapon is present, not just weapons of the same subtype.
                 },

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Rockets and Torpedoes/FixedgunRLXcascade.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Rockets and Torpedoes/FixedgunRLXcascade.cs
@@ -133,7 +133,7 @@ namespace Scripts
                 },
                 Other = new OtherDef
                 {
-                    ConstructPartCap = 4, //preformance Maximum number of blocks with this weapon on a grid; 0 = unlimited.
+                    ConstructPartCap = 0, //preformance Maximum number of blocks with this weapon on a grid; 0 = unlimited.
                     RotateBarrelAxis = 0, // For spinning barrels, which axis to spin the barrel around; 0 = none.
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.

--- a/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Rockets and Torpedoes/SpitfireRocketLauncher.cs
+++ b/Weapon Mods/Development/TIOStarcore-Dev/Data/Scripts/CoreParts/Rockets and Torpedoes/SpitfireRocketLauncher.cs
@@ -110,7 +110,7 @@ namespace Scripts {
                 },
                 Other = new OtherDef
                 {
-                    ConstructPartCap = 12, //preformance reasons // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
+                    ConstructPartCap = 0, //preformance reasons // Maximum number of blocks with this weapon on a grid; 0 = unlimited.
                     RotateBarrelAxis = 0, // For spinning barrels, which axis to spin the barrel around; 0 = none.
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = false, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.


### PR DESCRIPTION
removing limits, points adjusted for climbing cost

[MID] AX 'Spitfire' Light Rocket Turret: 100bp -> 75bp + 15% climbing cost
[MID] LK 'Bonfire' Guided Rocket Turret: 400bp -> 300bp + 20% climbing cost

[FLAW] Naval RL-10x 'Avalanche' Launchers: 750bp -> 635bp + 15% climbing cost
[FLAW] Goalkeeper Casemate Flak Battery: 200bp -> 175bp + 12% climbing cost
[FLAW] Hadean Plasma Blastguns: 900bp -> 825bp + 12% climbing cost
[FLAW] Vindicator Kinetic Battery: 800bp -> 750bp + 12% climbing cost

[FLAW] Phoenix Snubfighters: 300bp -> 230bp + 10% climbing cost
[FLAW] Longsword Bombers: 400bp -> 800bp --> 625bp + 20% climbing cost


updated Cubeblocks to reflect the company
said I set component mod of shipwreck to -1 in patchnotes but i must of forgot, pushing that now.
